### PR TITLE
顧客マスタにChatwork連携・チャットマスタ新設

### DIFF
--- a/data/mock-data.js
+++ b/data/mock-data.js
@@ -45,16 +45,16 @@ const MOCK_DATA = {
   ],
 
   clients: [
-    { id: 'c-001', clientCode: '030450', name: '株式会社サンプル商事', clientType: '法人', fiscalMonth: 3, isActive: true, mainUserId: 'u-003', subUserId: 'u-007', mgrUserId: 'u-003', monthlySales: 50000, address: '東京都千代田区大手町1-1-1', tel: '03-1234-5001', representative: '山本 太郎', establishDate: '2010-05-20', industry: '卸売業', taxOffice: '千代田税務署', memo: '' },
-    { id: 'c-002', clientCode: '030451', name: '合同会社テスト工業', clientType: '法人', fiscalMonth: 9, isActive: true, mainUserId: 'u-004', subUserId: null, mgrUserId: 'u-004', monthlySales: 30000, address: '大阪府大阪市中央区本町2-2-2', tel: '06-1234-5002', representative: '鈴木 一郎', establishDate: '2015-03-10', industry: '製造業', taxOffice: '東税務署', memo: '' },
-    { id: 'c-003', clientCode: '030452', name: '田中 一郎', clientType: '個人', fiscalMonth: 12, isActive: true, mainUserId: 'u-005', subUserId: 'u-006', mgrUserId: 'u-005', monthlySales: 20000, address: '愛知県名古屋市中区栄3-3-3', tel: '052-1234-5003', representative: '', establishDate: '', industry: '不動産賃貸', taxOffice: '名古屋中税務署', memo: '不動産所得あり' },
-    { id: 'c-004', clientCode: '030453', name: '株式会社リベ不動産', clientType: '法人', fiscalMonth: 6, isActive: true, mainUserId: 'u-003', subUserId: null, mgrUserId: 'u-003', monthlySales: 80000, address: '大阪府大阪市北区梅田1-4-4', tel: '06-1234-5004', representative: '高橋 花子', establishDate: '2018-01-15', industry: '不動産業', taxOffice: '北税務署', memo: '' },
-    { id: 'c-005', clientCode: '030454', name: '佐藤 二郎', clientType: '個人', fiscalMonth: 12, isActive: true, mainUserId: 'u-006', subUserId: null, mgrUserId: 'u-005', monthlySales: 15000, address: '福岡県福岡市博多区博多駅前5-5-5', tel: '092-1234-5005', representative: '', establishDate: '', industry: 'フリーランス（IT）', taxOffice: '博多税務署', memo: '' },
-    { id: 'c-006', clientCode: '030455', name: '有限会社グリーンファーム', clientType: '法人', fiscalMonth: 8, isActive: true, mainUserId: 'u-007', subUserId: null, mgrUserId: 'u-003', monthlySales: 25000, address: '北海道札幌市中央区北1条6-6-6', tel: '011-1234-5006', representative: '田村 健太', establishDate: '2005-09-01', industry: '農業', taxOffice: '札幌中税務署', memo: '' },
-    { id: 'c-007', clientCode: '030456', name: '株式会社デジタルソリューション', clientType: '法人', fiscalMonth: 12, isActive: true, mainUserId: 'u-004', subUserId: 'u-006', mgrUserId: 'u-004', monthlySales: 100000, address: '東京都渋谷区渋谷2-7-7', tel: '03-1234-5007', representative: '中村 誠', establishDate: '2020-02-14', industry: 'IT・ソフトウェア', taxOffice: '渋谷税務署', memo: '顧問契約プレミアムプラン' },
-    { id: 'c-008', clientCode: '030457', name: '山田 花子', clientType: '個人', fiscalMonth: 12, isActive: false, mainUserId: 'u-005', subUserId: null, mgrUserId: 'u-005', monthlySales: 10000, address: '京都府京都市左京区8-8-8', tel: '075-1234-5008', representative: '', establishDate: '', industry: '小売業', taxOffice: '左京税務署', memo: '2025年解約済み' },
-    { id: 'c-009', clientCode: '030458', name: '株式会社スカイブルー', clientType: '法人', fiscalMonth: 1, isActive: true, mainUserId: 'u-003', subUserId: 'u-005', mgrUserId: 'u-003', monthlySales: 45000, address: '神奈川県横浜市西区みなとみらい9-9-9', tel: '045-1234-5009', representative: '木村 翔', establishDate: '2019-11-01', industry: 'サービス業', taxOffice: '横浜中税務署', memo: '' },
-    { id: 'c-010', clientCode: '030459', name: 'NPO法人サポートネット', clientType: '法人', fiscalMonth: 3, isActive: true, mainUserId: 'u-006', subUserId: null, mgrUserId: 'u-009', monthlySales: 18000, address: '兵庫県神戸市中央区三宮10-10-10', tel: '078-1234-5010', representative: '佐々木 みどり', establishDate: '2012-06-30', industry: 'NPO・福祉', taxOffice: '神戸税務署', memo: '' },
+    { id: 'c-001', clientCode: '030450', name: '株式会社サンプル商事', clientType: '法人', fiscalMonth: 3, isActive: true, mainUserId: 'u-003', subUserId: 'u-007', mgrUserId: 'u-003', monthlySales: 50000, address: '東京都千代田区大手町1-1-1', tel: '03-1234-5001', representative: '山本 太郎', establishDate: '2010-05-20', industry: '卸売業', taxOffice: '千代田税務署', memo: '', cwAccountId: '1234001', cwAccountName: '山本太郎（サンプル商事）' },
+    { id: 'c-002', clientCode: '030451', name: '合同会社テスト工業', clientType: '法人', fiscalMonth: 9, isActive: true, mainUserId: 'u-004', subUserId: null, mgrUserId: 'u-004', monthlySales: 30000, address: '大阪府大阪市中央区本町2-2-2', tel: '06-1234-5002', representative: '鈴木 一郎', establishDate: '2015-03-10', industry: '製造業', taxOffice: '東税務署', memo: '', cwAccountId: '1234002', cwAccountName: '鈴木一郎（テスト工業）' },
+    { id: 'c-003', clientCode: '030452', name: '田中 一郎', clientType: '個人', fiscalMonth: 12, isActive: true, mainUserId: 'u-005', subUserId: 'u-006', mgrUserId: 'u-005', monthlySales: 20000, address: '愛知県名古屋市中区栄3-3-3', tel: '052-1234-5003', representative: '', establishDate: '', industry: '不動産賃貸', taxOffice: '名古屋中税務署', memo: '不動産所得あり', cwAccountId: '1234003', cwAccountName: '田中一郎' },
+    { id: 'c-004', clientCode: '030453', name: '株式会社リベ不動産', clientType: '法人', fiscalMonth: 6, isActive: true, mainUserId: 'u-003', subUserId: null, mgrUserId: 'u-003', monthlySales: 80000, address: '大阪府大阪市北区梅田1-4-4', tel: '06-1234-5004', representative: '高橋 花子', establishDate: '2018-01-15', industry: '不動産業', taxOffice: '北税務署', memo: '', cwAccountId: '1234004', cwAccountName: '高橋花子（リベ不動産）' },
+    { id: 'c-005', clientCode: '030454', name: '佐藤 二郎', clientType: '個人', fiscalMonth: 12, isActive: true, mainUserId: 'u-006', subUserId: null, mgrUserId: 'u-005', monthlySales: 15000, address: '福岡県福岡市博多区博多駅前5-5-5', tel: '092-1234-5005', representative: '', establishDate: '', industry: 'フリーランス（IT）', taxOffice: '博多税務署', memo: '', cwAccountId: '', cwAccountName: '' },
+    { id: 'c-006', clientCode: '030455', name: '有限会社グリーンファーム', clientType: '法人', fiscalMonth: 8, isActive: true, mainUserId: 'u-007', subUserId: null, mgrUserId: 'u-003', monthlySales: 25000, address: '北海道札幌市中央区北1条6-6-6', tel: '011-1234-5006', representative: '田村 健太', establishDate: '2005-09-01', industry: '農業', taxOffice: '札幌中税務署', memo: '', cwAccountId: '1234006', cwAccountName: '田村健太（グリーンファーム）' },
+    { id: 'c-007', clientCode: '030456', name: '株式会社デジタルソリューション', clientType: '法人', fiscalMonth: 12, isActive: true, mainUserId: 'u-004', subUserId: 'u-006', mgrUserId: 'u-004', monthlySales: 100000, address: '東京都渋谷区渋谷2-7-7', tel: '03-1234-5007', representative: '中村 誠', establishDate: '2020-02-14', industry: 'IT・ソフトウェア', taxOffice: '渋谷税務署', memo: '顧問契約プレミアムプラン', cwAccountId: '1234007', cwAccountName: '中村誠（デジタルソリューション）' },
+    { id: 'c-008', clientCode: '030457', name: '山田 花子', clientType: '個人', fiscalMonth: 12, isActive: false, mainUserId: 'u-005', subUserId: null, mgrUserId: 'u-005', monthlySales: 10000, address: '京都府京都市左京区8-8-8', tel: '075-1234-5008', representative: '', establishDate: '', industry: '小売業', taxOffice: '左京税務署', memo: '2025年解約済み', cwAccountId: '', cwAccountName: '' },
+    { id: 'c-009', clientCode: '030458', name: '株式会社スカイブルー', clientType: '法人', fiscalMonth: 1, isActive: true, mainUserId: 'u-003', subUserId: 'u-005', mgrUserId: 'u-003', monthlySales: 45000, address: '神奈川県横浜市西区みなとみらい9-9-9', tel: '045-1234-5009', representative: '木村 翔', establishDate: '2019-11-01', industry: 'サービス業', taxOffice: '横浜中税務署', memo: '', cwAccountId: '1234009', cwAccountName: '木村翔（スカイブルー）' },
+    { id: 'c-010', clientCode: '030459', name: 'NPO法人サポートネット', clientType: '法人', fiscalMonth: 3, isActive: true, mainUserId: 'u-006', subUserId: null, mgrUserId: 'u-009', monthlySales: 18000, address: '兵庫県神戸市中央区三宮10-10-10', tel: '078-1234-5010', representative: '佐々木 みどり', establishDate: '2012-06-30', industry: 'NPO・福祉', taxOffice: '神戸税務署', memo: '', cwAccountId: '1234010', cwAccountName: '佐々木みどり（サポートネット）' },
   ],
 
   tasks: [
@@ -177,6 +177,19 @@ const MOCK_DATA = {
     { id: 'rw-010', userId: 'u-007', month: '2026-03', clientId: 'c-006', amount: 3750, type: '税務顧問' },
   ],
 
+  // チャットマスタ（Chatworkルーム）
+  chatRooms: [
+    { id: 'cr-001', roomId: '300000001', roomName: '【リベ税】株式会社サンプル商事', roomUrl: 'https://www.chatwork.com/#!rid300000001', clientIds: ['c-001'], memo: '' },
+    { id: 'cr-002', roomId: '300000002', roomName: '【リベ税】合同会社テスト工業', roomUrl: 'https://www.chatwork.com/#!rid300000002', clientIds: ['c-002'], memo: '' },
+    { id: 'cr-003', roomId: '300000003', roomName: '【リベ税】田中一郎', roomUrl: 'https://www.chatwork.com/#!rid300000003', clientIds: ['c-003'], memo: '' },
+    { id: 'cr-004', roomId: '300000004', roomName: '【リベ税】株式会社リベ不動産', roomUrl: 'https://www.chatwork.com/#!rid300000004', clientIds: ['c-004'], memo: '' },
+    { id: 'cr-005', roomId: '300000005', roomName: '【リベ税】有限会社グリーンファーム', roomUrl: 'https://www.chatwork.com/#!rid300000005', clientIds: ['c-006'], memo: '' },
+    { id: 'cr-006', roomId: '300000006', roomName: '【リベ税】デジタルソリューション', roomUrl: 'https://www.chatwork.com/#!rid300000006', clientIds: ['c-007'], memo: '' },
+    { id: 'cr-007', roomId: '300000007', roomName: '【リベ税】スカイブルー', roomUrl: 'https://www.chatwork.com/#!rid300000007', clientIds: ['c-009'], memo: '' },
+    { id: 'cr-008', roomId: '300000008', roomName: '【リベ税】NPOサポートネット', roomUrl: 'https://www.chatwork.com/#!rid300000008', clientIds: ['c-010'], memo: '' },
+    { id: 'cr-009', roomId: '300000009', roomName: '【リベ税】セキュリティ連絡', roomUrl: 'https://www.chatwork.com/#!rid300000009', clientIds: ['c-001', 'c-002', 'c-004', 'c-006', 'c-007', 'c-009', 'c-010'], memo: 'セキュリティ関連の一斉連絡用' },
+  ],
+
   notifications: [
     { id: 'n-001', type: 'task_due', message: '株式会社サンプル商事「法人税確定申告書作成」の期限が3日後です', isRead: false, createdAt: '2026-03-10T09:00:00' },
     { id: 'n-002', type: 'task_assigned', message: '新しいタスク「決算報告書レビュー」が割り当てられました', isRead: false, createdAt: '2026-03-10T08:30:00' },
@@ -190,6 +203,9 @@ function getUserById(id) { return MOCK_DATA.users.find(u => u.id === id); }
 function getClientById(id) { return MOCK_DATA.clients.find(c => c.id === id); }
 function getTasksByClient(clientId) { return MOCK_DATA.tasks.filter(t => t.clientId === clientId); }
 function getTasksByAssignee(userId) { return MOCK_DATA.tasks.filter(t => t.assigneeUserId === userId); }
+
+function getChatRoomsByClient(clientId) { return MOCK_DATA.chatRooms.filter(r => r.clientIds.includes(clientId)); }
+function getChatRoomById(id) { return MOCK_DATA.chatRooms.find(r => r.id === id); }
 
 function getRoleBadge(role) {
   const map = { superadmin: 'SA', admin: '管理者', team_leader: 'TL', member: 'メンバー' };

--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
       <a href="#" data-page="reports">&#x1f4dd; 報告書</a>
       <a href="#" data-page="calendar">&#x1f4c5; カレンダー</a>
 
+      <div class="nav-section">チャット</div>
+      <a href="#" data-page="chatrooms">&#x1f4ac; チャットマスタ</a>
+
       <div class="nav-section">報酬</div>
       <a href="#" data-page="rewards">&#x1f4b0; 報酬管理</a>
 
@@ -194,6 +197,19 @@
       <div class="form-group">
         <label>月額報酬（税抜・円）</label>
         <input type="number" id="new-client-sales" placeholder="50000" min="0" step="1000">
+      </div>
+      <div style="border-top:1px solid var(--gray-200);padding-top:16px;margin-top:8px;">
+        <div style="font-size:13px;font-weight:600;color:var(--gray-700);margin-bottom:12px;">Chatwork連携</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+          <div class="form-group">
+            <label>CWアカウントID</label>
+            <input type="text" id="new-client-cw-id" placeholder="例: 1234567">
+          </div>
+          <div class="form-group">
+            <label>CW表示名</label>
+            <input type="text" id="new-client-cw-name" placeholder="例: 山本太郎">
+          </div>
+        </div>
       </div>
     </div>
     <div class="modal-footer">
@@ -507,6 +523,46 @@
     <div class="modal-footer">
       <button class="btn btn-secondary" onclick="closeProgressSettingsModal()">キャンセル</button>
       <button class="btn btn-primary" onclick="submitEditProgress()">保存</button>
+    </div>
+  </div>
+</div>
+
+<!-- チャットルーム追加/編集モーダル -->
+<div class="modal-overlay" id="chatroom-create-modal">
+  <div class="modal modal-wide">
+    <div class="modal-header">
+      <h3 id="chatroom-modal-title">チャットルーム登録</h3>
+      <button class="btn-icon" onclick="closeChatRoomModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <input type="hidden" id="edit-chatroom-id">
+      <div class="form-group">
+        <label>ルーム名</label>
+        <input type="text" id="new-cr-name" placeholder="例: 【リベ税】株式会社サンプル商事">
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="form-group">
+          <label>ルームID</label>
+          <input type="text" id="new-cr-roomid" placeholder="例: 300000001">
+        </div>
+        <div class="form-group">
+          <label>ルームURL</label>
+          <input type="text" id="new-cr-url" placeholder="https://www.chatwork.com/#!rid...">
+        </div>
+      </div>
+      <div class="form-group">
+        <label>紐づけ顧客（複数選択可）</label>
+        <div id="cr-client-checkboxes" style="max-height:180px;overflow-y:auto;border:1px solid var(--gray-200);border-radius:6px;padding:8px 12px;"></div>
+      </div>
+      <div class="form-group">
+        <label>備考</label>
+        <input type="text" id="new-cr-memo" placeholder="例: セキュリティ関連の一斉連絡用">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-danger btn-sm" id="cr-delete-btn" onclick="deleteChatRoom()" style="margin-right:auto;display:none">削除</button>
+      <button class="btn btn-secondary" onclick="closeChatRoomModal()">キャンセル</button>
+      <button class="btn btn-primary" onclick="submitChatRoom()">登録</button>
     </div>
   </div>
 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@ function navigateTo(pageName, params = {}) {
     reports: '報告書',
     calendar: 'カレンダー',
     rewards: '報酬管理',
+    chatrooms: 'チャットマスタ',
     integrations: '外部連携',
     settings: 'マイ設定',
   };
@@ -293,6 +294,8 @@ function openClientModal(clientId) {
       document.getElementById('new-client-main').value = c.mainUserId || '';
       document.getElementById('new-client-sub').value = c.subUserId || '';
       document.getElementById('new-client-fiscal').value = c.fiscalMonth || 3;
+      document.getElementById('new-client-cw-id').value = c.cwAccountId || '';
+      document.getElementById('new-client-cw-name').value = c.cwAccountName || '';
     }
   } else {
     document.getElementById('new-client-name').value = '';
@@ -303,6 +306,8 @@ function openClientModal(clientId) {
     document.getElementById('new-client-industry').value = '';
     document.getElementById('new-client-representative').value = '';
     document.getElementById('new-client-taxoffice').value = '';
+    document.getElementById('new-client-cw-id').value = '';
+    document.getElementById('new-client-cw-name').value = '';
   }
 
   modal.classList.add('show');
@@ -324,6 +329,8 @@ function submitNewClient() {
   const industry = document.getElementById('new-client-industry').value.trim();
   const representative = document.getElementById('new-client-representative').value.trim();
   const taxOffice = document.getElementById('new-client-taxoffice').value.trim();
+  const cwAccountId = document.getElementById('new-client-cw-id').value.trim();
+  const cwAccountName = document.getElementById('new-client-cw-name').value.trim();
 
   if (!name) { alert('顧客名を入力してください'); return; }
   if (!monthlySales) { alert('月額報酬を入力してください'); return; }
@@ -344,6 +351,8 @@ function submitNewClient() {
       c.industry = industry;
       c.representative = representative;
       c.taxOffice = taxOffice;
+      c.cwAccountId = cwAccountId;
+      c.cwAccountName = cwAccountName;
     }
     closeClientModal();
     navigateTo('client-detail', { id: editingClientId });
@@ -371,6 +380,8 @@ function submitNewClient() {
       taxOffice,
       memo: '',
       establishDate: '',
+      cwAccountId,
+      cwAccountName,
     });
 
     closeClientModal();
@@ -705,6 +716,7 @@ function registerAllPages() {
   registerPage('reports', renderReports);
   registerPage('calendar', renderCalendar);
   registerPage('rewards', renderRewards);
+  registerPage('chatrooms', renderChatRooms);
   registerPage('integrations', renderIntegrations);
   registerPage('settings', renderSettings);
 }
@@ -884,13 +896,28 @@ function renderClientDetail(el, params) {
           <div class="detail-row"><div class="detail-label">ステータス</div><div class="detail-value">${c.isActive ? '有効' : '無効'}</div></div>
         </div>
       </div>
-      <div class="card">
-        <div class="card-header"><h3>担当者</h3></div>
-        <div class="card-body">
-          <div class="detail-row"><div class="detail-label">主担当</div><div class="detail-value">${main?.name || '-'}</div></div>
-          <div class="detail-row"><div class="detail-label">副担当</div><div class="detail-value">${sub?.name || '-'}</div></div>
-          <div class="detail-row"><div class="detail-label">担当税理士</div><div class="detail-value">${mgr?.name || '-'}</div></div>
-          <div class="detail-row"><div class="detail-label">外部リンク</div><div class="detail-value"><a href="#" onclick="event.preventDefault();window.open('https://www.dropbox.com','_blank')">Dropboxフォルダを開く</a></div></div>
+      <div>
+        <div class="card" style="margin-bottom:16px">
+          <div class="card-header"><h3>担当者</h3></div>
+          <div class="card-body">
+            <div class="detail-row"><div class="detail-label">主担当</div><div class="detail-value">${main?.name || '-'}</div></div>
+            <div class="detail-row"><div class="detail-label">副担当</div><div class="detail-value">${sub?.name || '-'}</div></div>
+            <div class="detail-row"><div class="detail-label">担当税理士</div><div class="detail-value">${mgr?.name || '-'}</div></div>
+            <div class="detail-row"><div class="detail-label">外部リンク</div><div class="detail-value"><a href="#" onclick="event.preventDefault();window.open('https://www.dropbox.com','_blank')">Dropboxフォルダを開く</a></div></div>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-header"><h3>Chatwork連携</h3></div>
+          <div class="card-body">
+            <div class="detail-row"><div class="detail-label">CWアカウントID</div><div class="detail-value">${c.cwAccountId ? c.cwAccountId : '<span style="color:var(--gray-400)">未設定</span>'}</div></div>
+            <div class="detail-row"><div class="detail-label">CW表示名</div><div class="detail-value">${c.cwAccountName || '<span style="color:var(--gray-400)">未設定</span>'}</div></div>
+            <div class="detail-row"><div class="detail-label">メンション</div><div class="detail-value">${c.cwAccountId ? '<code style="background:var(--gray-100);padding:2px 6px;border-radius:3px;font-size:12px;">[To:' + c.cwAccountId + ']' + (c.cwAccountName || c.name) + 'さん</code>' : '<span style="color:var(--gray-400)">-</span>'}</div></div>
+            ${(() => {
+              const rooms = getChatRoomsByClient(c.id);
+              if (rooms.length === 0) return '<div class="detail-row"><div class="detail-label">関連ルーム</div><div class="detail-value"><span style="color:var(--gray-400)">なし</span></div></div>';
+              return rooms.map(r => `<div class="detail-row"><div class="detail-label">関連ルーム</div><div class="detail-value"><a href="${r.roomUrl}" target="_blank">${r.roomName}</a></div></div>`).join('');
+            })()}
+          </div>
         </div>
       </div>
     </div>
@@ -2484,4 +2511,201 @@ function renderSettings(el) {
       document.getElementById('settings-panel').innerHTML = panels[btn.dataset.tab] || '';
     });
   });
+}
+
+// ===========================
+// チャットマスタ
+// ===========================
+function renderChatRooms(el) {
+  el.innerHTML = `
+    <div class="toolbar">
+      <input type="text" class="search-input" placeholder="ルーム名・顧客名で検索..." id="cr-search">
+      <div class="spacer"></div>
+      <button class="btn btn-primary" onclick="openChatRoomModal()">+ ルーム追加</button>
+    </div>
+    <div class="card">
+      <div class="table-wrapper">
+        <table>
+          <thead><tr><th>ルーム名</th><th>ルームID</th><th>紐づけ顧客</th><th>備考</th><th style="width:60px"></th></tr></thead>
+          <tbody id="cr-table-body"></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card" style="margin-top:24px">
+      <div class="card-header"><h3>メンション一括コピー</h3></div>
+      <div class="card-body">
+        <p style="font-size:13px;color:var(--gray-500);margin-bottom:12px;">ルームを選択すると、そのルームに紐づく顧客のChatworkメンションを一括コピーできます。</p>
+        <div style="display:flex;gap:12px;align-items:flex-end;">
+          <div class="form-group" style="flex:1;margin-bottom:0;">
+            <label>対象ルーム</label>
+            <select id="cr-mention-room" style="width:100%;padding:8px 12px;border:1px solid var(--gray-300);border-radius:6px;font-size:13px;">
+              <option value="">-- ルームを選択 --</option>
+              ${MOCK_DATA.chatRooms.map(r => `<option value="${r.id}">${r.roomName}</option>`).join('')}
+            </select>
+          </div>
+          <button class="btn btn-secondary" onclick="copyMentions()">メンションをコピー</button>
+        </div>
+        <pre id="cr-mention-preview" style="margin-top:12px;padding:12px;background:var(--gray-50);border-radius:6px;font-size:12px;white-space:pre-wrap;display:none;"></pre>
+      </div>
+    </div>
+  `;
+  renderChatRoomTable();
+  document.getElementById('cr-search').addEventListener('input', renderChatRoomTable);
+  document.getElementById('cr-mention-room').addEventListener('change', previewMentions);
+}
+
+function renderChatRoomTable() {
+  const search = (document.getElementById('cr-search')?.value || '').toLowerCase();
+  let rooms = MOCK_DATA.chatRooms;
+  if (search) {
+    rooms = rooms.filter(r => {
+      if (r.roomName.toLowerCase().includes(search)) return true;
+      return r.clientIds.some(cid => {
+        const c = getClientById(cid);
+        return c && c.name.toLowerCase().includes(search);
+      });
+    });
+  }
+
+  const tbody = document.getElementById('cr-table-body');
+  tbody.innerHTML = rooms.map(r => {
+    const clientNames = r.clientIds.map(cid => {
+      const c = getClientById(cid);
+      return c ? `<a href="#" onclick="event.preventDefault();navigateTo('client-detail',{id:'${cid}'})">${c.name}</a>` : cid;
+    }).join(', ');
+    return `<tr>
+      <td><strong>${r.roomName}</strong></td>
+      <td style="font-family:monospace;font-size:12px;">${r.roomId}</td>
+      <td>${clientNames}</td>
+      <td style="color:var(--gray-500);font-size:12px;">${r.memo || '-'}</td>
+      <td><button class="btn btn-secondary btn-sm" onclick="openChatRoomModal('${r.id}')">編集</button></td>
+    </tr>`;
+  }).join('');
+}
+
+function previewMentions() {
+  const roomId = document.getElementById('cr-mention-room').value;
+  const pre = document.getElementById('cr-mention-preview');
+  if (!roomId) { pre.style.display = 'none'; return; }
+
+  const room = getChatRoomById(roomId);
+  if (!room) { pre.style.display = 'none'; return; }
+
+  const mentions = room.clientIds.map(cid => {
+    const c = getClientById(cid);
+    if (!c || !c.cwAccountId) return null;
+    return `[To:${c.cwAccountId}]${c.cwAccountName || c.name}さん`;
+  }).filter(Boolean);
+
+  if (mentions.length === 0) {
+    pre.textContent = '（CWアカウントIDが設定されている顧客がいません）';
+  } else {
+    pre.textContent = mentions.join('\n');
+  }
+  pre.style.display = 'block';
+}
+
+function copyMentions() {
+  const pre = document.getElementById('cr-mention-preview');
+  if (!pre || pre.style.display === 'none' || !pre.textContent) {
+    alert('ルームを選択してください');
+    return;
+  }
+  navigator.clipboard.writeText(pre.textContent).then(() => {
+    alert('メンションをクリップボードにコピーしました');
+  });
+}
+
+let editingChatRoomId = null;
+
+function openChatRoomModal(roomId) {
+  editingChatRoomId = roomId || null;
+  const modal = document.getElementById('chatroom-create-modal');
+  const title = document.getElementById('chatroom-modal-title');
+  const deleteBtn = document.getElementById('cr-delete-btn');
+
+  // 顧客チェックボックスを生成
+  const checkboxes = document.getElementById('cr-client-checkboxes');
+  checkboxes.innerHTML = MOCK_DATA.clients.filter(c => c.isActive).map(c =>
+    `<label style="display:flex;align-items:center;gap:6px;font-size:13px;padding:4px 0;cursor:pointer;">
+      <input type="checkbox" value="${c.id}" class="cr-client-cb"> ${c.name}
+      ${c.cwAccountId ? '<span style="font-size:11px;color:var(--gray-400);">(CW: ' + c.cwAccountId + ')</span>' : '<span style="font-size:11px;color:var(--warning);">(CW未設定)</span>'}
+    </label>`
+  ).join('');
+
+  if (editingChatRoomId) {
+    title.textContent = 'チャットルーム編集';
+    deleteBtn.style.display = '';
+    const r = getChatRoomById(editingChatRoomId);
+    if (r) {
+      document.getElementById('edit-chatroom-id').value = r.id;
+      document.getElementById('new-cr-name').value = r.roomName;
+      document.getElementById('new-cr-roomid').value = r.roomId;
+      document.getElementById('new-cr-url').value = r.roomUrl;
+      document.getElementById('new-cr-memo').value = r.memo || '';
+      document.querySelectorAll('.cr-client-cb').forEach(cb => {
+        cb.checked = r.clientIds.includes(cb.value);
+      });
+    }
+  } else {
+    title.textContent = 'チャットルーム登録';
+    deleteBtn.style.display = 'none';
+    document.getElementById('edit-chatroom-id').value = '';
+    document.getElementById('new-cr-name').value = '';
+    document.getElementById('new-cr-roomid').value = '';
+    document.getElementById('new-cr-url').value = '';
+    document.getElementById('new-cr-memo').value = '';
+    document.querySelectorAll('.cr-client-cb').forEach(cb => { cb.checked = false; });
+  }
+
+  modal.classList.add('show');
+}
+
+function closeChatRoomModal() {
+  document.getElementById('chatroom-create-modal').classList.remove('show');
+  editingChatRoomId = null;
+}
+
+function submitChatRoom() {
+  const roomName = document.getElementById('new-cr-name').value.trim();
+  const roomId = document.getElementById('new-cr-roomid').value.trim();
+  const roomUrl = document.getElementById('new-cr-url').value.trim();
+  const memo = document.getElementById('new-cr-memo').value.trim();
+  const clientIds = [...document.querySelectorAll('.cr-client-cb:checked')].map(cb => cb.value);
+
+  if (!roomName) { alert('ルーム名を入力してください'); return; }
+  if (!roomId) { alert('ルームIDを入力してください'); return; }
+
+  if (editingChatRoomId) {
+    const r = getChatRoomById(editingChatRoomId);
+    if (r) {
+      r.roomName = roomName;
+      r.roomId = roomId;
+      r.roomUrl = roomUrl || `https://www.chatwork.com/#!rid${roomId}`;
+      r.clientIds = clientIds;
+      r.memo = memo;
+    }
+  } else {
+    const newId = 'cr-' + String(MOCK_DATA.chatRooms.length + 1).padStart(3, '0');
+    MOCK_DATA.chatRooms.push({
+      id: newId,
+      roomId,
+      roomName,
+      roomUrl: roomUrl || `https://www.chatwork.com/#!rid${roomId}`,
+      clientIds,
+      memo,
+    });
+  }
+
+  closeChatRoomModal();
+  if (currentPage === 'chatrooms') navigateTo('chatrooms');
+}
+
+function deleteChatRoom() {
+  if (!editingChatRoomId) return;
+  if (!confirm('このチャットルームを削除しますか？')) return;
+  const idx = MOCK_DATA.chatRooms.findIndex(r => r.id === editingChatRoomId);
+  if (idx >= 0) MOCK_DATA.chatRooms.splice(idx, 1);
+  closeChatRoomModal();
+  navigateTo('chatrooms');
 }


### PR DESCRIPTION
## Summary
- 顧客マスタにCWアカウントID・CW表示名フィールドを追加（登録/編集/詳細画面）
- チャットマスタ（別テーブル）を新設し、Chatworkルームと顧客の紐づけ管理を実装
- チャットマスタ画面でルーム選択→メンション一括コピー機能

## 背景
セキュリティ連絡等のBOTメッセージで顧客にメンションを付ける際、「誰にメンションするか」の情報が散在していた。顧客マスタにCWアカウントIDを持たせ、チャットルームとの紐づけを管理することで、メンション作成の手間を削減する。

## 変更ファイル
- `data/mock-data.js` — 顧客にcwAccountId/cwAccountName追加、chatRoomsテーブル新設
- `index.html` — サイドバーにチャットマスタリンク、顧客モーダルにCWフィールド、チャットルームモーダル追加
- `js/app.js` — 顧客詳細CW連携セクション、チャットマスタページ、メンション一括コピー機能

## プレビュー
https://raw.githack.com/libetax-development/client-management-demo/feature/chatwork-integration/index.html

## Test plan
- [ ] ログイン後、サイドバーに「チャットマスタ」が表示されること
- [ ] チャットマスタ画面でルーム一覧が表示されること
- [ ] ルームの追加/編集/削除が動作すること
- [ ] メンション一括コピーが動作すること
- [ ] 顧客一覧→顧客詳細で「Chatwork連携」セクションが表示されること
- [ ] 顧客登録/編集モーダルでCWアカウントID・CW表示名が入力できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)