### PR TITLE
モック機能強化: コメント・カレンダー・報告書詳細

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -241,6 +241,10 @@ tbody tr.clickable { cursor: pointer; }
 .rp-search-opts label { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--gray-600); margin-bottom: 6px; cursor: pointer; }
 .rp-search-actions { display: flex; gap: 8px; margin-top: 14px; }
 .rp-search-actions .btn { flex: 1; font-size: 12px; justify-content: center; }
+.rp-rank-display { display: inline-block; padding: 2px 10px; border-radius: 4px; font-size: 12px; font-weight: 700; }
+.rp-rank-A { background: #fee2e2; color: #991b1b; }
+.rp-rank-B { background: #fef3c7; color: #92400e; }
+.rp-rank-C { background: var(--gray-100); color: var(--gray-600); }
 
 @media (max-width: 900px) {
   .rp-layout { grid-template-columns: 1fr; }
@@ -303,6 +307,12 @@ tbody tr.clickable { cursor: pointer; }
 .cal-event.status-done { background: #dcfce7; color: #166534; }
 .cal-event.status-returned { background: #fee2e2; color: #991b1b; }
 .cal-more { font-size: 10px; color: var(--gray-400); padding: 2px 4px; }
+.cal-event-meeting { background: #fef3c7; color: #92400e; }
+.cal-event-internal { background: #e0e7ff; color: #3730a3; }
+.cal-event-deadline { background: #fee2e2; color: #991b1b; font-weight: 600; }
+.cal-event-type-badge.cal-event-meeting { background: #fef3c7; color: #92400e; }
+.cal-event-type-badge.cal-event-internal { background: #e0e7ff; color: #3730a3; }
+.cal-event-type-badge.cal-event-deadline { background: #fee2e2; color: #991b1b; }
 
 /* ── 通知ドロップダウン ── */
 .notif-dropdown { position: absolute; top: calc(100% + 8px); right: 0; width: 380px; background: #fff; border-radius: var(--radius); border: 1px solid var(--gray-200); box-shadow: var(--shadow-lg); z-index: 300; display: none; }

--- a/data/mock-data.js
+++ b/data/mock-data.js
@@ -219,6 +219,35 @@ const MOCK_DATA = {
     { id: 'al-010', timestamp: '2026-02-01T00:00:00', ruleId: 'ar-006', ruleName: '決算期限自動算出', result: '成功', targetCount: 2 },
   ],
 
+  // タスクコメント
+  taskComments: [
+    { id: 'tc-001', taskId: 'tk-001', authorId: 'u-003', body: '仕訳データの確認が完了しました。申告書のドラフトに着手します。', createdAt: '2026-03-08T14:30:00' },
+    { id: 'tc-002', taskId: 'tk-001', authorId: 'u-002', body: '資料の追加が必要です。決算整理仕訳の根拠資料を確認してください。', createdAt: '2026-03-09T10:15:00' },
+    { id: 'tc-003', taskId: 'tk-001', authorId: 'u-003', body: '承知しました。本日中に確認して追記します。', createdAt: '2026-03-09T11:00:00' },
+    { id: 'tc-004', taskId: 'tk-004', authorId: 'u-005', body: '医療費控除の明細書が未提出です。顧客に連絡済み。', createdAt: '2026-03-07T16:00:00' },
+    { id: 'tc-005', taskId: 'tk-004', authorId: 'u-009', body: '3/10までに届かなければ先に他の部分を進めてください。', createdAt: '2026-03-08T09:00:00' },
+    { id: 'tc-006', taskId: 'tk-006', authorId: 'u-002', body: '売上計上のタイミングに誤りがあります。修正をお願いします。', createdAt: '2026-03-06T15:30:00' },
+    { id: 'tc-007', taskId: 'tk-006', authorId: 'u-006', body: '修正しました。再度レビューをお願いいたします。', createdAt: '2026-03-07T11:00:00' },
+    { id: 'tc-008', taskId: 'tk-008', authorId: 'u-007', body: '入力完了。売上仕訳の確認待ちです。', createdAt: '2026-03-10T17:00:00' },
+    { id: 'tc-009', taskId: 'tk-010', authorId: 'u-006', body: 'NPO法人の活動計算書フォーマットで作成中です。', createdAt: '2026-03-09T13:00:00' },
+  ],
+
+  // カレンダーイベント（面談・MTG等）
+  calendarEvents: [
+    { id: 'ev-001', title: '株式会社サンプル商事 決算打ち合わせ', date: '2026-03-18', time: '10:00', duration: 60, type: 'meeting', userId: 'u-003', clientId: 'c-001', location: 'Zoom' },
+    { id: 'ev-002', title: '田中一郎 確定申告面談', date: '2026-03-14', time: '14:00', duration: 30, type: 'meeting', userId: 'u-005', clientId: 'c-003', location: '来所' },
+    { id: 'ev-003', title: '全体ミーティング', date: '2026-03-17', time: '09:00', duration: 60, type: 'internal', userId: null, clientId: null, location: 'Zoom' },
+    { id: 'ev-004', title: '株式会社リベ不動産 月次報告', date: '2026-03-20', time: '15:00', duration: 45, type: 'meeting', userId: 'u-003', clientId: 'c-004', location: 'Zoom' },
+    { id: 'ev-005', title: 'デジタルソリューション 月次面談', date: '2026-03-14', time: '10:00', duration: 60, type: 'meeting', userId: 'u-004', clientId: 'c-007', location: 'Zoom' },
+    { id: 'ev-006', title: '新人研修（税務基礎）', date: '2026-03-19', time: '13:00', duration: 120, type: 'internal', userId: null, clientId: null, location: '会議室A' },
+    { id: 'ev-007', title: 'NPOサポートネット 決算説明', date: '2026-03-25', time: '11:00', duration: 60, type: 'meeting', userId: 'u-006', clientId: 'c-010', location: '来所' },
+    { id: 'ev-008', title: '佐藤二郎 確定申告最終確認', date: '2026-03-12', time: '16:00', duration: 30, type: 'meeting', userId: 'u-006', clientId: 'c-005', location: '電話' },
+    { id: 'ev-009', title: 'チームリーダー定例', date: '2026-03-21', time: '09:00', duration: 30, type: 'internal', userId: null, clientId: null, location: 'Zoom' },
+    { id: 'ev-010', title: '確定申告期限', date: '2026-03-16', time: null, duration: null, type: 'deadline', userId: null, clientId: null, location: null },
+    { id: 'ev-011', title: 'スカイブルー 法人税相談', date: '2026-03-26', time: '14:00', duration: 45, type: 'meeting', userId: 'u-003', clientId: 'c-009', location: 'Zoom' },
+    { id: 'ev-012', title: 'グリーンファーム 記帳確認', date: '2026-03-13', time: '11:00', duration: 30, type: 'meeting', userId: 'u-007', clientId: 'c-006', location: '電話' },
+  ],
+
   notifications: [
     { id: 'n-001', type: 'task_due', message: '株式会社サンプル商事「法人税確定申告書作成」の期限が3日後です', isRead: false, createdAt: '2026-03-10T09:00:00' },
     { id: 'n-002', type: 'task_assigned', message: '新しいタスク「決算報告書レビュー」が割り当てられました', isRead: false, createdAt: '2026-03-10T08:30:00' },
@@ -235,6 +264,8 @@ function getTasksByAssignee(userId) { return MOCK_DATA.tasks.filter(t => t.assig
 
 function getChatRoomsByClient(clientId) { return MOCK_DATA.chatRooms.filter(r => r.clientIds.includes(clientId)); }
 function getChatRoomById(id) { return MOCK_DATA.chatRooms.find(r => r.id === id); }
+function getTaskComments(taskId) { return MOCK_DATA.taskComments.filter(c => c.taskId === taskId).sort((a, b) => a.createdAt.localeCompare(b.createdAt)); }
+function getCalendarEvents(dateStr) { return MOCK_DATA.calendarEvents.filter(e => e.date === dateStr); }
 
 function getRoleBadge(role) {
   const map = { superadmin: 'SA', admin: '管理者', team_leader: 'TL', member: 'メンバー' };

--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,7 @@ function navigateTo(pageName, params = {}) {
     'staff-detail': '職員詳細',
     timesheet: '工数管理',
     reports: '報告書',
+    'report-detail': '報告書詳細',
     calendar: 'カレンダー',
     rewards: '報酬管理',
     chatrooms: 'チャットマスタ',
@@ -765,6 +766,7 @@ function registerAllPages() {
   registerPage('staff-detail', renderStaffDetail);
   registerPage('timesheet', renderTimesheet);
   registerPage('reports', renderReports);
+  registerPage('report-detail', renderReportDetail);
   registerPage('calendar', renderCalendar);
   registerPage('rewards', renderRewards);
   registerPage('chatrooms', renderChatRooms);
@@ -1385,19 +1387,57 @@ function renderTaskDetail(el, params) {
         <div class="card">
           <div class="card-header"><h3>コメント</h3></div>
           <div class="card-body">
-            <div style="padding:12px;background:var(--gray-50);border-radius:6px;margin-bottom:12px;">
-              <div style="font-size:12px;color:var(--gray-500);margin-bottom:4px;">齋藤 太郎 - 2026/03/08</div>
-              <div style="font-size:13px;">仕訳データの確認が完了しました。申告書のドラフトに着手します。</div>
-            </div>
+            <div id="task-comments-list"></div>
             <div style="display:flex;gap:8px;">
-              <input type="text" class="search-input" style="flex:1;width:auto" placeholder="コメントを入力...">
-              <button class="btn btn-primary btn-sm">送信</button>
+              <input type="text" class="search-input" id="task-comment-input" style="flex:1;width:auto" placeholder="コメントを入力...">
+              <button class="btn btn-primary btn-sm" id="task-comment-send">送信</button>
             </div>
           </div>
         </div>
       </div>
     </div>
   `;
+
+  renderTaskComments(t.id);
+
+  document.getElementById('task-comment-send').addEventListener('click', () => submitTaskComment(t.id));
+  document.getElementById('task-comment-input').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitTaskComment(t.id); }
+  });
+}
+
+function renderTaskComments(taskId) {
+  const comments = getTaskComments(taskId);
+  const container = document.getElementById('task-comments-list');
+  if (comments.length === 0) {
+    container.innerHTML = '<div style="padding:12px;color:var(--gray-400);font-size:13px;">コメントはまだありません</div>';
+    return;
+  }
+  container.innerHTML = comments.map(c => {
+    const author = getUserById(c.authorId);
+    return `<div style="padding:12px;background:var(--gray-50);border-radius:6px;margin-bottom:8px;">
+      <div style="font-size:12px;color:var(--gray-500);margin-bottom:4px;">${author?.name || '-'} - ${formatDate(c.createdAt)}</div>
+      <div style="font-size:13px;">${escapeHtml(c.body)}</div>
+    </div>`;
+  }).join('');
+}
+
+function submitTaskComment(taskId) {
+  const input = document.getElementById('task-comment-input');
+  const body = input.value.trim();
+  if (!body) return;
+
+  const newId = 'tc-' + String(MOCK_DATA.taskComments.length + 1).padStart(3, '0');
+  MOCK_DATA.taskComments.push({
+    id: newId,
+    taskId: taskId,
+    authorId: MOCK_DATA.currentUser.id,
+    body: body,
+    createdAt: new Date().toISOString(),
+  });
+
+  input.value = '';
+  renderTaskComments(taskId);
 }
 
 // ===========================
@@ -2174,12 +2214,146 @@ function rpMarkAllRead() {
 function rpClickReport(id) {
   const r = MOCK_DATA.reports.find(x => x.id === id);
   if (r && r.readStatus === '未読') r.readStatus = '既読';
-  if (rpExpandedSet.has(id)) {
-    rpExpandedSet.delete(id);
-  } else {
-    rpExpandedSet.add(id);
+  navigateTo('report-detail', { id });
+}
+
+// ===========================
+// 報告書詳細
+// ===========================
+function renderReportDetail(el, params) {
+  const r = MOCK_DATA.reports.find(x => x.id === params.id);
+  if (!r) { el.innerHTML = '<div class="empty-state"><div class="icon">?</div><p>報告書が見つかりません</p></div>'; return; }
+  const author = getUserById(r.authorId);
+  document.getElementById('header-title').textContent = `報告書詳細 - ${r.title}`;
+
+  // モック本文を種別に応じて生成
+  const mockBody = generateReportBody(r);
+
+  el.innerHTML = `
+    <div style="margin-bottom:16px"><a href="#" onclick="event.preventDefault();navigateTo('reports')">&larr; 報告書一覧に戻る</a></div>
+    <div class="detail-grid">
+      <div class="card">
+        <div class="card-header">
+          <h3>${r.title}</h3>
+          <div style="display:flex;gap:8px;">
+            <span class="rp-row-badge ${r.readStatus === '未読' ? 'rp-badge-unread' : r.readStatus === '一時保存中' ? 'rp-badge-draft' : 'rp-badge-read'}">${r.readStatus}</span>
+          </div>
+        </div>
+        <div class="card-body">
+          <div style="white-space:pre-wrap;font-size:13px;line-height:1.8;color:var(--gray-700);">${escapeHtml(mockBody)}</div>
+          ${r.hasAttachment ? '<div style="margin-top:16px;padding:12px;background:var(--gray-50);border-radius:6px;"><span style="font-size:13px;">&#128206; 添付ファイル: <a href="#" onclick="event.preventDefault();alert(\'ファイルを開きます（モック）\')">' + r.title.slice(0, 20) + '_資料.pdf</a></span></div>' : ''}
+        </div>
+      </div>
+      <div>
+        <div class="card" style="margin-bottom:16px;">
+          <div class="card-header"><h3>報告書情報</h3></div>
+          <div class="card-body">
+            <div class="detail-row"><div class="detail-label">作成者</div><div class="detail-value">${author?.name || '-'}</div></div>
+            <div class="detail-row"><div class="detail-label">作成日時</div><div class="detail-value">${formatDate(r.createdAt)}</div></div>
+            <div class="detail-row"><div class="detail-label">種別</div><div class="detail-value">${r.type}</div></div>
+            <div class="detail-row"><div class="detail-label">業務分類</div><div class="detail-value">${r.category}</div></div>
+            <div class="detail-row"><div class="detail-label">顧客</div><div class="detail-value">${r.clientName || '-'}</div></div>
+            <div class="detail-row"><div class="detail-label">ランク</div><div class="detail-value"><span class="rp-rank-display rp-rank-${r.rank}">${r.rank}</span></div></div>
+            <div class="detail-row"><div class="detail-label">添付ファイル</div><div class="detail-value">${r.hasAttachment ? 'あり' : 'なし'}</div></div>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-header"><h3>操作</h3></div>
+          <div class="card-body" style="display:flex;flex-direction:column;gap:8px;">
+            <button class="btn btn-secondary btn-sm" onclick="alert('Chatworkに転送しました（モック）')">Chatworkに転送</button>
+            <button class="btn btn-secondary btn-sm" onclick="alert('PDFをダウンロードしました（モック）')">PDF出力</button>
+            ${r.readStatus === '一時保存中' ? '<button class="btn btn-primary btn-sm" onclick="rpSubmitDraft(\'' + r.id + '\')">提出する</button>' : ''}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function rpSubmitDraft(id) {
+  const r = MOCK_DATA.reports.find(x => x.id === id);
+  if (r) {
+    r.readStatus = '未読';
+    navigateTo('report-detail', { id });
   }
-  rpRenderList();
+}
+
+function generateReportBody(r) {
+  if (r.type === '日報') {
+    return `【日報】${r.title}
+
+■ 本日の業務内容
+・顧客対応（面談・メール・チャット）
+・書類作成・チェック業務
+・社内ミーティング参加
+
+■ 明日の予定
+・申告書類の最終確認
+・顧客フォローアップ
+
+■ 所感・連絡事項
+特になし`;
+  }
+  const templates = {
+    '確定申告': `【確定申告】${r.clientName}
+
+■ 作業内容
+${r.title}
+
+■ 実施事項
+・会計帳簿のチェック（仕訳内容・勘定科目の確認）
+・前年度との比較分析
+・不明点の洗い出しと顧客への確認事項整理
+
+■ 確認事項
+・売上計上基準の確認が必要
+・経費の按分比率について顧客に確認中
+
+■ 次のアクション
+・顧客からの回答待ち → 回答後に申告書ドラフト作成予定
+・レビュー依頼予定日: 未定`,
+
+    '決算業務': `【決算業務】${r.clientName}
+
+■ 作業内容
+${r.title}
+
+■ 実施事項
+・決算整理仕訳の確認
+・減価償却費の計算
+・引当金の計上確認
+
+■ 特記事項
+・固定資産台帳との照合完了
+・税効果会計の適用確認中
+
+■ 次のアクション
+・申告書作成に着手予定`,
+
+    '月次業務': `【月次業務】${r.clientName}
+
+■ 作業内容
+${r.title}
+
+■ 実施事項
+・月次試算表の作成
+・前月比較分析
+・資金繰り表の更新
+
+■ 連絡事項
+・異常値なし
+・顧客への月次報告完了`,
+  };
+  return templates[r.category] || `【${r.category}】${r.clientName}
+
+■ 作業内容
+${r.title}
+
+■ 実施事項
+・業務対応実施
+
+■ 備考
+特になし`;
 }
 
 function rpExpandAll() {
@@ -2250,6 +2424,11 @@ function renderCalendar(el) {
       <h3 id="cal-title" style="margin:0 16px;min-width:140px;text-align:center;"></h3>
       <button class="btn btn-secondary" id="cal-next">次月 &rarr;</button>
       <div class="spacer"></div>
+      <select class="filter-select" id="cal-type-filter">
+        <option value="">全て表示</option>
+        <option value="task">タスク期限のみ</option>
+        <option value="event">イベントのみ</option>
+      </select>
       <select class="filter-select" id="cal-user-filter">
         <option value="">全担当者</option>
         ${MOCK_DATA.users.filter(u => u.isActive).map(u => `<option value="${u.id}">${u.name}</option>`).join('')}
@@ -2260,19 +2439,26 @@ function renderCalendar(el) {
         <div class="cal-grid" id="cal-grid"></div>
       </div>
     </div>
+    <div id="cal-day-detail" style="display:none;margin-top:16px;"></div>
   `;
 
   function draw() {
     document.getElementById('cal-title').textContent = `${calYear}年${calMonth + 1}月`;
     const userFilter = document.getElementById('cal-user-filter')?.value || '';
+    const typeFilter = document.getElementById('cal-type-filter')?.value || '';
     const firstDay = new Date(calYear, calMonth, 1).getDay();
     const daysInMonth = new Date(calYear, calMonth + 1, 0).getDate();
     const today = new Date().toISOString().slice(0, 10);
 
-    let tasks = MOCK_DATA.tasks.filter(t => {
+    let tasks = typeFilter !== 'event' ? MOCK_DATA.tasks.filter(t => {
       if (userFilter && t.assigneeUserId !== userFilter) return false;
       return true;
-    });
+    }) : [];
+
+    let events = typeFilter !== 'task' ? MOCK_DATA.calendarEvents.filter(e => {
+      if (userFilter && e.userId && e.userId !== userFilter) return false;
+      return true;
+    }) : [];
 
     const dayHeaders = ['日', '月', '火', '水', '木', '金', '土'];
     let html = dayHeaders.map((d, i) => `<div class="cal-header ${i === 0 ? 'cal-sun' : i === 6 ? 'cal-sat' : ''}">${d}</div>`).join('');
@@ -2286,23 +2472,101 @@ function renderCalendar(el) {
       const isToday = dateStr === today;
       const dow = (firstDay + d - 1) % 7;
       const dayTasks = tasks.filter(t => t.dueDate === dateStr);
+      const dayEvents = events.filter(e => e.date === dateStr);
+      const allItems = [];
 
-      html += `<div class="cal-day ${isToday ? 'cal-today' : ''} ${dow === 0 ? 'cal-sun' : dow === 6 ? 'cal-sat' : ''}">
+      dayTasks.forEach(t => {
+        const client = getClientById(t.clientId);
+        allItems.push({ html: `<div class="cal-event ${getStatusClass(t.status)}" title="${client?.name}: ${t.title}">${client?.name?.slice(0, 6) || ''} ${t.title.slice(0, 8)}</div>` });
+      });
+      dayEvents.forEach(e => {
+        const typeClass = e.type === 'deadline' ? 'cal-event-deadline' : e.type === 'internal' ? 'cal-event-internal' : 'cal-event-meeting';
+        const timeStr = e.time ? e.time + ' ' : '';
+        allItems.push({ html: `<div class="cal-event ${typeClass}" title="${e.title}${e.location ? ' (' + e.location + ')' : ''}">${timeStr}${e.title.slice(0, 10)}</div>` });
+      });
+
+      html += `<div class="cal-day ${isToday ? 'cal-today' : ''} ${dow === 0 ? 'cal-sun' : dow === 6 ? 'cal-sat' : ''}" data-date="${dateStr}" style="cursor:pointer;">
         <div class="cal-date">${d}</div>
-        ${dayTasks.slice(0, 3).map(t => {
-          const client = getClientById(t.clientId);
-          return `<div class="cal-event ${getStatusClass(t.status)}" title="${client?.name}: ${t.title}">${client?.name?.slice(0, 6) || ''} ${t.title.slice(0, 8)}</div>`;
-        }).join('')}
-        ${dayTasks.length > 3 ? `<div class="cal-more">+${dayTasks.length - 3}件</div>` : ''}
+        ${allItems.slice(0, 3).map(i => i.html).join('')}
+        ${allItems.length > 3 ? `<div class="cal-more">+${allItems.length - 3}件</div>` : ''}
       </div>`;
     }
 
     document.getElementById('cal-grid').innerHTML = html;
+
+    // 日付クリックで詳細表示
+    document.querySelectorAll('.cal-day[data-date]').forEach(cell => {
+      cell.addEventListener('click', () => showCalDayDetail(cell.dataset.date, userFilter, typeFilter));
+    });
+  }
+
+  function showCalDayDetail(dateStr, userFilter, typeFilter) {
+    const detail = document.getElementById('cal-day-detail');
+    const dayTasks = typeFilter !== 'event' ? MOCK_DATA.tasks.filter(t => {
+      if (t.dueDate !== dateStr) return false;
+      if (userFilter && t.assigneeUserId !== userFilter) return false;
+      return true;
+    }) : [];
+    const dayEvents = typeFilter !== 'task' ? MOCK_DATA.calendarEvents.filter(e => {
+      if (e.date !== dateStr) return false;
+      if (userFilter && e.userId && e.userId !== userFilter) return false;
+      return true;
+    }) : [];
+
+    if (dayTasks.length === 0 && dayEvents.length === 0) {
+      detail.style.display = 'none';
+      return;
+    }
+
+    const d = new Date(dateStr);
+    const dateLabel = `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+
+    let html = `<div class="card">
+      <div class="card-header"><h3>${dateLabel} の予定</h3><button class="btn-icon" onclick="document.getElementById('cal-day-detail').style.display='none'">&times;</button></div>
+      <div class="card-body">`;
+
+    if (dayEvents.length > 0) {
+      html += '<div style="margin-bottom:12px;"><div style="font-size:12px;font-weight:600;color:var(--gray-500);margin-bottom:8px;">イベント</div>';
+      html += dayEvents.map(e => {
+        const user = e.userId ? getUserById(e.userId) : null;
+        const client = e.clientId ? getClientById(e.clientId) : null;
+        const typeLabel = { meeting: '面談', internal: '社内', deadline: '期限' }[e.type] || e.type;
+        return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--gray-100);">
+          <span class="cal-event-type-badge cal-event-${e.type}" style="font-size:11px;padding:2px 8px;border-radius:4px;font-weight:600;">${typeLabel}</span>
+          <div style="flex:1;">
+            <div style="font-size:13px;font-weight:500;">${e.time ? e.time + ' ' : ''}${e.title}</div>
+            <div style="font-size:11px;color:var(--gray-400);">${[user?.name, client?.name, e.location].filter(Boolean).join(' / ')}</div>
+          </div>
+        </div>`;
+      }).join('');
+      html += '</div>';
+    }
+
+    if (dayTasks.length > 0) {
+      html += '<div><div style="font-size:12px;font-weight:600;color:var(--gray-500);margin-bottom:8px;">タスク期限</div>';
+      html += dayTasks.map(t => {
+        const client = getClientById(t.clientId);
+        const assignee = getUserById(t.assigneeUserId);
+        return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--gray-100);cursor:pointer;" onclick="navigateTo('task-detail',{id:'${t.id}'})">
+          <span class="status-badge ${getStatusClass(t.status)}">${t.status}</span>
+          <div style="flex:1;">
+            <div style="font-size:13px;font-weight:500;">${t.title}</div>
+            <div style="font-size:11px;color:var(--gray-400);">${client?.name || '-'} / ${assignee?.name || '-'}</div>
+          </div>
+        </div>`;
+      }).join('');
+      html += '</div>';
+    }
+
+    html += '</div></div>';
+    detail.innerHTML = html;
+    detail.style.display = 'block';
   }
 
   document.getElementById('cal-prev').addEventListener('click', () => { calMonth--; if (calMonth < 0) { calMonth = 11; calYear--; } draw(); });
   document.getElementById('cal-next').addEventListener('click', () => { calMonth++; if (calMonth > 11) { calMonth = 0; calYear++; } draw(); });
   document.getElementById('cal-user-filter').addEventListener('change', draw);
+  document.getElementById('cal-type-filter').addEventListener('change', draw);
   draw();
 }
 


### PR DESCRIPTION
## Summary
- タスク詳細のコメント送信機能を実装（モックデータで動的追加・Enter送信対応）
- カレンダーに面談・MTG等のイベントデータ12件を追加、種別フィルタ・日付クリック詳細パネル
- 報告書詳細ページを新設（種別ごとのモック本文生成・CW転送/PDF出力ボタン・一時保存→提出機能）

## Test plan
- [ ] タスク詳細画面でコメント入力→送信が動作すること
- [ ] カレンダーに面談イベントが色分けで表示されること
- [ ] カレンダーの日付クリックで詳細パネルが表示されること
- [ ] 報告書一覧→クリックで詳細ページに遷移すること
- [ ] 報告書詳細でモック本文が種別に応じて表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)