### PR TITLE
インラインスタイルをCSSユーティリティクラスに移行

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -423,6 +423,20 @@ textarea.inline-edit-input { resize: vertical; font-family: inherit; }
 .ai-sg-desc { font-size: 13px; color: var(--gray-600); line-height: 1.6; margin-bottom: 10px; }
 .ai-sg-actions { display: flex; gap: 8px; }
 
+/* ── ユーティリティクラス ── */
+.text-muted { color: var(--gray-400); font-size: 13px; }
+.text-hint { color: var(--gray-500); font-size: 13px; }
+.text-label { font-size: 12px; font-weight: 600; color: var(--gray-500); margin-bottom: 8px; }
+.flex-row { display: flex; align-items: center; gap: 12px; }
+.flex-col { display: flex; flex-direction: column; gap: 8px; }
+.info-box { padding: 12px; background: var(--gray-50); border-radius: 6px; }
+.pre-wrap { white-space: pre-wrap; font-size: 13px; line-height: 1.8; color: var(--gray-700); }
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.list-item-row { display: flex; align-items: center; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--gray-100); }
+.section-divider { border-top: 1px solid var(--gray-200); padding-top: 16px; margin-top: 8px; }
+.section-title-sm { font-size: 13px; font-weight: 600; color: var(--gray-700); margin-bottom: 12px; }
+.stat-unit { font-size: 14px; font-weight: 400; color: var(--gray-500); }
+
 @media (max-width: 768px) {
   .hamburger { display: block; }
   .sidebar { transform: translateX(-100%); transition: transform .25s; }

--- a/js/ai/index.js
+++ b/js/ai/index.js
@@ -142,7 +142,7 @@ function renderAIDraft(panel) {
   panel.innerHTML = `
     <div class="card">
       <div class="card-body">
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="grid-2">
           <div class="form-group">
             <label>顧客</label>
             <select id="ai-draft-client">
@@ -407,15 +407,15 @@ function renderAISuggestionResults() {
     <div class="stats-grid">
       <div class="stat-card accent-blue">
         <div class="stat-label">提案数</div>
-        <div class="stat-value">${aiSuggestions.length}<span style="font-size:14px;font-weight:400;color:var(--gray-500);">件</span></div>
+        <div class="stat-value">${aiSuggestions.length}<span class="stat-unit">件</span></div>
       </div>
       <div class="stat-card accent-red">
         <div class="stat-label">期限超過タスク</div>
-        <div class="stat-value">${overdueTasks}<span style="font-size:14px;font-weight:400;color:var(--gray-500);">件</span></div>
+        <div class="stat-value">${overdueTasks}<span class="stat-unit">件</span></div>
       </div>
       <div class="stat-card accent-yellow">
         <div class="stat-label">来月決算の顧客</div>
-        <div class="stat-value">${nextMonthClients}<span style="font-size:14px;font-weight:400;color:var(--gray-500);">社</span></div>
+        <div class="stat-value">${nextMonthClients}<span class="stat-unit">社</span></div>
       </div>
     </div>
   `;

--- a/js/calendar/index.js
+++ b/js/calendar/index.js
@@ -114,12 +114,12 @@ function renderCalendar(el) {
       <div class="card-body">`;
 
     if (dayEvents.length > 0) {
-      html += '<div style="margin-bottom:12px;"><div style="font-size:12px;font-weight:600;color:var(--gray-500);margin-bottom:8px;">イベント</div>';
+      html += '<div style="margin-bottom:12px;"><div class="text-label">イベント</div>';
       html += dayEvents.map(e => {
         const user = e.userId ? getUserById(e.userId) : null;
         const client = e.clientId ? getClientById(e.clientId) : null;
         const typeLabel = { meeting: '面談', internal: '社内', deadline: '期限' }[e.type] || e.type;
-        return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--gray-100);">
+        return `<div class="list-item-row">
           <span class="cal-event-type-badge cal-event-${e.type}" style="font-size:11px;padding:2px 8px;border-radius:4px;font-weight:600;">${typeLabel}</span>
           <div style="flex:1;">
             <div style="font-size:13px;font-weight:500;">${e.time ? e.time + ' ' : ''}${e.title}</div>
@@ -131,11 +131,11 @@ function renderCalendar(el) {
     }
 
     if (dayTasks.length > 0) {
-      html += '<div><div style="font-size:12px;font-weight:600;color:var(--gray-500);margin-bottom:8px;">タスク期限</div>';
+      html += '<div><div class="text-label">タスク期限</div>';
       html += dayTasks.map(t => {
         const client = getClientById(t.clientId);
         const assignee = getUserById(t.assigneeUserId);
-        return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--gray-100);cursor:pointer;" onclick="navigateTo('task-detail',{id:'${t.id}'})">
+        return `<div class="list-item-row" style="cursor:pointer;" onclick="navigateTo('task-detail',{id:'${t.id}'})">
           ${renderStatusBadge(t.status)}
           <div style="flex:1;">
             <div style="font-size:13px;font-weight:500;">${t.title}</div>

--- a/js/modals.js
+++ b/js/modals.js
@@ -60,8 +60,8 @@ function openClientModal(clientId) {
   const customFields = (MOCK_DATA.customFields || []).slice().sort((a, b) => a.order - b.order);
   if (customFields.length > 0) {
     cfArea.innerHTML = `
-      <div style="border-top:1px solid var(--gray-200);padding-top:16px;margin-top:8px;">
-        <div style="font-size:13px;font-weight:600;color:var(--gray-700);margin-bottom:12px;">カスタム項目</div>
+      <div class="section-divider">
+        <div class="section-title-sm">カスタム項目</div>
         ${customFields.map(cf => {
           let input = '';
           const inputId = 'cf-val-' + cf.id;

--- a/js/reports/index.js
+++ b/js/reports/index.js
@@ -227,8 +227,8 @@ function renderReportDetail(el, params) {
           </div>
         </div>
         <div class="card-body">
-          <div style="white-space:pre-wrap;font-size:13px;line-height:1.8;color:var(--gray-700);">${escapeHtml(mockBody)}</div>
-          ${r.hasAttachment ? '<div style="margin-top:16px;padding:12px;background:var(--gray-50);border-radius:6px;"><span style="font-size:13px;">&#128206; 添付ファイル: <a href="#" onclick="event.preventDefault();alert(\'ファイルを開きます（モック）\')">' + r.title.slice(0, 20) + '_資料.pdf</a></span></div>' : ''}
+          <div class="pre-wrap">${escapeHtml(mockBody)}</div>
+          ${r.hasAttachment ? '<div class="info-box" style="margin-top:16px;"><span style="font-size:13px;">&#128206; 添付ファイル: <a href="#" onclick="event.preventDefault();alert(\'ファイルを開きます（モック）\')">' + r.title.slice(0, 20) + '_資料.pdf</a></span></div>' : ''}
         </div>
       </div>
       <div>

--- a/js/tasks/index.js
+++ b/js/tasks/index.js
@@ -127,7 +127,7 @@ function renderTaskComments(taskId) {
   }
   container.innerHTML = comments.map(c => {
     const author = getUserById(c.authorId);
-    return `<div style="padding:12px;background:var(--gray-50);border-radius:6px;margin-bottom:8px;">
+    return `<div class="info-box" style="margin-bottom:8px;">
       <div style="font-size:12px;color:var(--gray-500);margin-bottom:4px;">${author?.name || '-'} - ${formatDate(c.createdAt)}</div>
       <div style="font-size:13px;">${escapeHtml(c.body)}</div>
     </div>`;


### PR DESCRIPTION
## Summary
- CSSに12個のユーティリティクラスを追加
- 6ファイル・13箇所のインラインスタイルをクラスに置換
- 完全一致またはサブセットのみ置換（保守的な適用）

### 追加したCSSクラス
`text-muted`, `text-hint`, `text-label`, `flex-row`, `flex-col`, `info-box`, `pre-wrap`, `grid-2`, `list-item-row`, `section-divider`, `section-title-sm`, `stat-unit`

## Test plan
- [ ] 全ページの見た目に変化がないこと
- [ ] カレンダー日付詳細・報告書詳細・AIアシスタントの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)