### PR TITLE
残りモック機能を実装（工数編集・自動化編集・イベント追加・Slack詳細）

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,6 +650,68 @@
   </div>
 </div>
 
+<!-- イベント追加モーダル -->
+<div class="modal-overlay" id="event-create-modal">
+  <div class="modal modal-wide">
+    <div class="modal-header">
+      <h3>イベント追加</h3>
+      <button class="btn-icon" onclick="closeEventModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-group">
+        <label>タイトル</label>
+        <input type="text" id="new-ev-title" placeholder="例: 株式会社サンプル 決算打ち合わせ">
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="form-group">
+          <label>日付</label>
+          <input type="date" id="new-ev-date">
+        </div>
+        <div class="form-group">
+          <label>時間</label>
+          <input type="time" id="new-ev-time">
+        </div>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="form-group">
+          <label>種別</label>
+          <select id="new-ev-type">
+            <option value="meeting">面談</option>
+            <option value="internal">社内</option>
+            <option value="deadline">期限</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>時間（分）</label>
+          <input type="number" id="new-ev-duration" placeholder="60" min="0" step="15">
+        </div>
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="form-group">
+          <label>担当者</label>
+          <select id="new-ev-user">
+            <option value="">なし</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>顧客</label>
+          <select id="new-ev-client">
+            <option value="">なし</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>場所</label>
+        <input type="text" id="new-ev-location" placeholder="例: Zoom / 来所 / 会議室A">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeEventModal()">キャンセル</button>
+      <button class="btn btn-primary" onclick="submitNewEvent()">作成</button>
+    </div>
+  </div>
+</div>
+
 <!-- CSV取り込み用の非表示input -->
 <input type="file" id="csv-import-input" accept=".csv" style="display:none">
 

--- a/js/automation/index.js
+++ b/js/automation/index.js
@@ -44,10 +44,31 @@ function runAutomationRule(ruleId) {
   }, 50);
 }
 
-function openAutomationModal() {
-  setFormValues({ 'new-auto-type': 'reminder' });
-  resetForm(['new-auto-name', 'new-auto-trigger', 'new-auto-action', 'new-auto-target']);
+let editingAutomationId = null;
+
+function openAutomationModal(ruleId) {
+  editingAutomationId = ruleId || null;
+  const modal = document.getElementById('automation-create-modal');
+  const title = modal.querySelector('.modal-header h3');
+
+  if (editingAutomationId) {
+    const rule = MOCK_DATA.automationRules.find(r => r.id === editingAutomationId);
+    if (rule) {
+      setFormValues({ 'new-auto-name': rule.name, 'new-auto-type': rule.type,
+                       'new-auto-trigger': rule.trigger, 'new-auto-action': rule.action,
+                       'new-auto-target': rule.target });
+    }
+    if (title) title.textContent = '自動化ルール編集';
+  } else {
+    setFormValues({ 'new-auto-type': 'reminder' });
+    resetForm(['new-auto-name', 'new-auto-trigger', 'new-auto-action', 'new-auto-target']);
+    if (title) title.textContent = '自動化ルール追加';
+  }
   showModal('automation-create-modal');
+}
+
+function editAutomationRule(id) {
+  openAutomationModal(id);
 }
 
 function closeAutomationModal() {
@@ -63,12 +84,28 @@ function submitNewAutomationRule() {
   if (!name) { alert('ルール名を入力してください'); return; }
   if (!trigger) { alert('トリガーを入力してください'); return; }
   if (!action) { alert('アクションを入力してください'); return; }
-  const newRule = {
-    id: 'ar-' + String(MOCK_DATA.automationRules.length + 1).padStart(3, '0'),
-    name, type, enabled: true, trigger, action, target, lastRun: null,
-  };
-  MOCK_DATA.automationRules.push(newRule);
+
+  if (editingAutomationId) {
+    const rule = MOCK_DATA.automationRules.find(r => r.id === editingAutomationId);
+    if (rule) {
+      Object.assign(rule, { name, type, trigger, action, target });
+    }
+    editingAutomationId = null;
+  } else {
+    const newRule = {
+      id: 'ar-' + String(MOCK_DATA.automationRules.length + 1).padStart(3, '0'),
+      name, type, enabled: true, trigger, action, target, lastRun: null,
+    };
+    MOCK_DATA.automationRules.push(newRule);
+  }
   closeAutomationModal();
+  const content = document.getElementById('page-content');
+  if (content) renderAutomation(content);
+}
+
+function deleteAutomationRule(id) {
+  if (!confirm('このルールを削除しますか？')) return;
+  MOCK_DATA.automationRules = MOCK_DATA.automationRules.filter(r => r.id !== id);
   const content = document.getElementById('page-content');
   if (content) renderAutomation(content);
 }
@@ -135,7 +172,9 @@ function renderAutomation(el) {
                 <td style="font-size:12px;color:var(--gray-600);">${r.target}</td>
                 <td style="font-size:12px;color:var(--gray-400);">${r.lastRun ? formatDateTime(r.lastRun) : '-'}</td>
                 <td>
+                  <button class="btn btn-secondary btn-sm" onclick="editAutomationRule('${r.id}')" style="font-size:11px;">編集</button>
                   <button class="btn btn-secondary btn-sm" onclick="runAutomationRule('${r.id}')" ${!r.enabled ? 'disabled style="opacity:0.5"' : ''}>今すぐ実行</button>
+                  <button class="btn-icon" onclick="deleteAutomationRule('${r.id}')" style="color:var(--danger);">&times;</button>
                   <div id="auto-flash-${r.id}"></div>
                 </td>
               </tr>

--- a/js/calendar/index.js
+++ b/js/calendar/index.js
@@ -21,6 +21,7 @@ function renderCalendar(el) {
         <option value="">全担当者</option>
         ${buildUserOptions()}
       </select>
+      <button class="btn btn-primary" id="cal-add-event">+ イベント追加</button>
     </div>
     <div class="card">
       <div class="card-body" style="padding:0;">
@@ -155,7 +156,38 @@ function renderCalendar(el) {
   document.getElementById('cal-next').addEventListener('click', () => { calMonth++; if (calMonth > 11) { calMonth = 0; calYear++; } draw(); });
   document.getElementById('cal-user-filter').addEventListener('change', draw);
   document.getElementById('cal-type-filter').addEventListener('change', draw);
+  document.getElementById('cal-add-event').addEventListener('click', openEventModal);
   draw();
+}
+
+function openEventModal() {
+  document.getElementById('new-ev-user').innerHTML = '<option value="">なし</option>' + buildUserOptions();
+  document.getElementById('new-ev-client').innerHTML = '<option value="">なし</option>' + buildClientOptions(true);
+  resetForm(['new-ev-title', 'new-ev-date', 'new-ev-time', 'new-ev-duration', 'new-ev-location']);
+  setFormValues({ 'new-ev-type': 'meeting' });
+  showModal('event-create-modal');
+}
+
+function closeEventModal() { hideModal('event-create-modal'); }
+
+function submitNewEvent() {
+  const title = getValTrim('new-ev-title');
+  const date = getVal('new-ev-date');
+  if (!title) { alert('タイトルを入力してください'); return; }
+  if (!date) { alert('日付を入力してください'); return; }
+
+  MOCK_DATA.calendarEvents.push({
+    id: generateId('ev-', MOCK_DATA.calendarEvents),
+    title, date,
+    time: getVal('new-ev-time') || null,
+    duration: getValInt('new-ev-duration') || null,
+    type: getVal('new-ev-type'),
+    userId: getVal('new-ev-user') || null,
+    clientId: getVal('new-ev-client') || null,
+    location: getValTrim('new-ev-location') || null,
+  });
+  closeEventModal();
+  navigateTo('calendar');
 }
 
 registerPage('calendar', renderCalendar);

--- a/js/integrations/index.js
+++ b/js/integrations/index.js
@@ -8,7 +8,7 @@ let integrationStates = {
   dropbox: { connected: true, account: 'libetax@dropbox.com', date: '2025-08-15', rootPath: '/リベ大税理士法人/顧客資料', usedStorage: '45.2 GB', totalStorage: '2 TB', autoCreateFolder: true, namingRule: '{顧客コード}_{顧客名}', lastSync: '2026-03-11T06:00:00' },
   zoom: { connected: false, account: '', date: '', lastSync: null },
   freee: { connected: true, account: 'リベ大税理士法人', date: '2025-06-01', lastSync: '2026-03-10T22:00:00' },
-  slack: { connected: false },
+  slack: { connected: false, workspaceUrl: '', channel: '', notifyTaskDue: true, notifyReportCreated: true, notifyEscalation: true },
   eltax: { connected: true, account: '利用者識別番号: 1234567890', date: '2025-09-01', lastSync: '2026-03-10T18:00:00' },
   etax: { connected: true, account: '利用者識別番号: 0987654321', date: '2025-09-01', lastSync: '2026-03-10T18:00:00' },
 };
@@ -179,6 +179,7 @@ function renderIntegrationDetails(key, st) {
   if (key === 'google') return renderGoogleDetails(st);
   if (key === 'dropbox') return renderDropboxDetails(st);
   if (key === 'zoom') return renderZoomDetails(st);
+  if (key === 'slack') return renderSlackDetails(st);
   // fallback for other integrations
   if (!st.connected) {
     return `<button class="btn btn-primary btn-sm" onclick="event.stopPropagation();toggleIntegration('${key}')">接続する</button>`;
@@ -347,6 +348,46 @@ function renderZoomDetails(st) {
         <button class="btn btn-danger btn-sm" onclick="event.stopPropagation();toggleIntegration('zoom')">切断</button>
       </div>
       <div id="int-flash-zoom"></div>
+    </div>`;
+}
+
+function renderSlackDetails(st) {
+  if (!st.connected) {
+    return `
+      <button class="btn btn-primary btn-sm" onclick="event.stopPropagation();toggleIntegration('slack')">接続する</button>`;
+  }
+  return `
+    <div class="int-detail-section">
+      <div class="form-group">
+        <label>Workspace URL</label>
+        <div style="display:flex;gap:8px;">
+          <input type="text" id="int-slack-workspace" value="${st.workspaceUrl || ''}" placeholder="libetax.slack.com" style="font-size:12px;padding:6px 8px;flex:1;">
+        </div>
+      </div>
+      <div class="form-group">
+        <label>通知チャンネル</label>
+        <input type="text" id="int-slack-channel" value="${st.channel || ''}" placeholder="#tax-notifications" style="font-size:12px;padding:6px 8px;">
+      </div>
+      <div class="form-group">
+        <label>通知設定</label>
+        <div style="display:flex;flex-direction:column;gap:6px;">
+          <label style="display:flex;align-items:center;gap:6px;font-size:12px;cursor:pointer;">
+            <input type="checkbox" ${st.notifyTaskDue !== false ? 'checked' : ''}> タスク期限通知
+          </label>
+          <label style="display:flex;align-items:center;gap:6px;font-size:12px;cursor:pointer;">
+            <input type="checkbox" ${st.notifyReportCreated !== false ? 'checked' : ''}> 報告書作成通知
+          </label>
+          <label style="display:flex;align-items:center;gap:6px;font-size:12px;cursor:pointer;">
+            <input type="checkbox" ${st.notifyEscalation !== false ? 'checked' : ''}> エスカレーション通知
+          </label>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;margin-top:12px;">
+        <button class="btn btn-primary btn-sm" onclick="event.stopPropagation();alert('テスト通知を送信しました（モック）')">テスト送信</button>
+        <button class="btn btn-secondary btn-sm" onclick="event.stopPropagation();alert('Slack設定を保存しました（モック）')">設定保存</button>
+        <button class="btn btn-danger btn-sm" onclick="event.stopPropagation();toggleIntegration('slack')">切断</button>
+      </div>
+      <div id="int-flash-slack"></div>
     </div>`;
 }
 

--- a/js/modals.js
+++ b/js/modals.js
@@ -303,11 +303,29 @@ function deleteTask() {
 }
 
 // ── 工数入力モーダル ──
-function openTimesheetModal() {
+let editingTimesheetId = null;
+
+function openTimesheetModal(entryId) {
+  editingTimesheetId = entryId || null;
   document.getElementById('new-ts-user').innerHTML = buildUserOptions();
   document.getElementById('new-ts-client').innerHTML = buildClientOptions(true);
-  setFormValues({ 'new-ts-date': new Date().toISOString().slice(0, 10) });
-  resetForm(['new-ts-hours', 'new-ts-desc']);
+
+  const modal = document.getElementById('timesheet-create-modal');
+  const title = modal.querySelector('.modal-header h3');
+
+  if (editingTimesheetId) {
+    const entry = MOCK_DATA.timeEntries.find(e => e.id === editingTimesheetId);
+    if (entry) {
+      setFormValues({ 'new-ts-user': entry.userId, 'new-ts-client': entry.clientId,
+                       'new-ts-date': entry.date, 'new-ts-hours': entry.hours,
+                       'new-ts-desc': entry.description });
+    }
+    if (title) title.textContent = '工数編集';
+  } else {
+    setFormValues({ 'new-ts-date': new Date().toISOString().slice(0, 10) });
+    resetForm(['new-ts-hours', 'new-ts-desc']);
+    if (title) title.textContent = '工数入力';
+  }
   showModal('timesheet-create-modal');
 }
 
@@ -323,13 +341,23 @@ function submitNewTimeEntry() {
   if (!hours || hours <= 0) { alert('時間を入力してください'); return; }
   if (!description) { alert('作業内容を入力してください'); return; }
 
-  MOCK_DATA.timeEntries.push({
-    id: generateId('te-', MOCK_DATA.timeEntries),
-    userId, clientId, taskId: null, date, hours, description,
-  });
-  closeTimesheetModal();
-  if (currentPage === 'timesheet') navigateTo('timesheet');
-  else alert('工数を登録しました');
+  if (editingTimesheetId) {
+    const entry = MOCK_DATA.timeEntries.find(e => e.id === editingTimesheetId);
+    if (entry) {
+      Object.assign(entry, { userId, clientId, date, hours, description });
+    }
+    editingTimesheetId = null;
+    closeTimesheetModal();
+    if (currentPage === 'timesheet') navigateTo('timesheet');
+  } else {
+    MOCK_DATA.timeEntries.push({
+      id: generateId('te-', MOCK_DATA.timeEntries),
+      userId, clientId, taskId: null, date, hours, description,
+    });
+    closeTimesheetModal();
+    if (currentPage === 'timesheet') navigateTo('timesheet');
+    else alert('工数を登録しました');
+  }
 }
 
 // ── 報告書作成モーダル ──

--- a/js/timesheet/index.js
+++ b/js/timesheet/index.js
@@ -20,7 +20,7 @@ function renderTimesheet(el) {
       <div class="card-body">
         <div class="table-wrapper">
           <table>
-            <thead><tr><th>日付</th><th>職員</th><th>顧客</th><th>作業内容</th><th>時間</th></tr></thead>
+            <thead><tr><th>日付</th><th>職員</th><th>顧客</th><th>作業内容</th><th>時間</th><th>操作</th></tr></thead>
             <tbody id="ts-table-body"></tbody>
           </table>
         </div>
@@ -79,8 +79,22 @@ function renderTimesheetData() {
       <td>${client?.name || '-'}</td>
       <td>${e.description}</td>
       <td><strong>${e.hours.toFixed(1)}h</strong></td>
+      <td>
+        <button class="btn btn-secondary btn-sm" onclick="editTimeEntry('${e.id}')" style="font-size:11px;">編集</button>
+        <button class="btn-icon" onclick="deleteTimeEntry('${e.id}')" style="color:var(--danger);">&times;</button>
+      </td>
     </tr>`;
-  }, 5);
+  }, 6);
+}
+
+function editTimeEntry(id) {
+  openTimesheetModal(id);
+}
+
+function deleteTimeEntry(id) {
+  if (!confirm('この工数エントリを削除しますか？')) return;
+  MOCK_DATA.timeEntries = MOCK_DATA.timeEntries.filter(e => e.id !== id);
+  renderTimesheetData();
 }
 
 registerPage('timesheet', renderTimesheet);


### PR DESCRIPTION
## Summary
- 工数管理: エントリの編集・削除機能を追加
- 自動化設定: ルールの編集・削除機能を追加
- カレンダー: イベント追加モーダルを新設（種別・担当者・顧客・場所）
- 外部連携: Slack連携の詳細パネルを追加（通知設定・チャンネル設定）

## Test plan
- [ ] 工数一覧で編集ボタン→モーダルにデータ反映→保存で更新
- [ ] 工数一覧で削除ボタン→確認→削除
- [ ] 自動化ルール一覧で編集ボタン→モーダルにデータ反映→保存
- [ ] 自動化ルールの削除が動作すること
- [ ] カレンダーの「+ イベント追加」→モーダル→作成→カレンダーに表示
- [ ] 外部連携でSlackカードを展開→詳細パネルが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)